### PR TITLE
fix: remove double-quotes from secret .ref values

### DIFF
--- a/internal/provider/osc_secret.go
+++ b/internal/provider/osc_secret.go
@@ -109,7 +109,7 @@ func (r *SecretResource) Create(ctx context.Context, req resource.CreateRequest,
 		}
 	}
 
-	ref := fmt.Sprintf("{{secrets.%s}}", plan.SecretName)
+	ref := fmt.Sprintf("{{secrets.%s}}", plan.SecretName.ValueString())
 	state := SecretResourceModel{
 		ServiceIds:  plan.ServiceIds,
 		SecretName:  plan.SecretName,
@@ -153,7 +153,7 @@ func (r *SecretResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		}
 	}
 
-	ref := fmt.Sprintf("{{secrets.%s}}", plan.SecretName)
+	ref := fmt.Sprintf("{{secrets.%s}}", plan.SecretName.ValueString())
 	state := SecretResourceModel{
 		ServiceIds:  plan.ServiceIds,
 		SecretName:  plan.SecretName,


### PR DESCRIPTION
Fixes #19

## Summary
- Remove extra double-quotes from secret .ref attribute values
- The ref now returns unquoted string (e.g. `secret.mysecret`) instead of `secret."mysecret"`
- Root cause: `plan.SecretName` is a `types.String`; using `%s` format includes surrounding quotes. Fixed by using `.ValueString()` in both Create and Delete handlers.

## Test plan
- [ ] Verify .ref returns unquoted value
- [ ] Check existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)