### PR TITLE
Drop gofmt step from regenerate workflow

### DIFF
--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -59,9 +59,12 @@ jobs:
             exit 1
           fi
 
-      - name: Format generated code
-        run: make fmt
-
+      # NB: we deliberately do NOT run `make fmt` here. The generator emits
+      # deterministic (if unformatted) Go, and the committed baseline is
+      # likewise unformatted, so skipping gofmt keeps the regeneration diff to
+      # real catalog changes only. `make fmt` also runs over the whole repo
+      # (gofmt -s -w .), which would reformat hand-written files and the
+      # generator source — out of scope for this workflow.
       - name: Verify it builds
         run: make build
 


### PR DESCRIPTION
PR #23 produced a ~214-file, +7k/−5k diff that was ~90% gofmt noise. Root cause: the `Format generated code` step runs `make fmt` = `gofmt -s -w .` over the **whole repo**, reformatting hand-written files and the generator source (`template/main.go`) against a baseline that was never gofmt'd.

This removes that step. The generator emits deterministic (if unformatted) Go matching the committed baseline, so future regeneration PRs show **only real catalog changes**. Code still builds (`make build` retained); no CI lint gate enforces gofmt.

A comment is added so gofmt isn't re-introduced by accident.

After merging, re-run the `Regenerate resources` workflow — the resulting PR should supersede #23 with a clean diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)